### PR TITLE
Only update state in componentWillReceiveProps when needed

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -196,8 +196,10 @@ export default class extends Component {
   loopJumpTimer = null
 
   componentWillReceiveProps (nextProps) {
-    if (!nextProps.autoplay && this.autoplayTimer) clearTimeout(this.autoplayTimer)
-    this.setState(this.initState(nextProps, this.props.index !== nextProps.index))
+    if (!nextProps.autoplay && this.autoplayTimer){
+      clearTimeout(this.autoplayTimer);
+      this.setState(this.initState(nextProps, this.props.index !== nextProps.index))
+    }
   }
 
   componentDidMount () {


### PR DESCRIPTION
Only update state in componentWillReceiveProps when needed. This was causing an issue when a modal with a swiper was open and the screen was rotated on iPad. This solution is taken from: https://github.com/leecade/react-native-swiper/issues/632

Anand confirmed that this code fixes the aforementioned issue and doesn't affect any current functionality.